### PR TITLE
Fix `Program.cs`

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -131,7 +131,7 @@ namespace PackForIP
 
             var assemblies = Directory.GetFiles(BuildFolder, "*.dll");
 
-            var regices = platform == "opemod" ? ExcludeAssemblies.BuildOpenmodRegices() : ExcludeAssemblies.BuildRocketmodRegices();
+            var regices = platform == "openmod" ? ExcludeAssemblies.BuildOpenmodRegices() : ExcludeAssemblies.BuildRocketmodRegices();
 
             var validAsms = new List<string>();
 


### PR DESCRIPTION
Change misspelling "opemod" to "openmod"

I think that i found a misspelling, maybe this error can break program (idk because i don't use this program).